### PR TITLE
Don't fail build on missing translation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,9 +11,14 @@ android {
         versionCode 17
         versionName "1.0.1-12.01.2018"
     }
+
     buildTypes {
         release {
         }
+    }
+
+    lintOptions {
+        disable 'MissingTranslation'
     }
 }
 


### PR DESCRIPTION
Build failed because of lint MissingTranslation: https://f-droid.org/wiki/page/de.vanitasvitae.enigmandroid/lastbuild_17

You can move the tag to this commit once merged...